### PR TITLE
#171037171 Any user, registered or not can search for teams and their fixtures

### DIFF
--- a/src/__tests__/teamRoute.test.js
+++ b/src/__tests__/teamRoute.test.js
@@ -180,6 +180,13 @@ describe('Add Teams', () => {
         expect(res.body.errors.message).toEqual('Team not found');
         done();
       });
+      it('should return details of a team and fixtures', async (done) => {
+        const res = await request(app)
+          .get(`${ApiPrefix}/teams/search?keyword=kiwi fc`)
+          .set('Authorization', `Bearer ${userToken}`)
+        expect(res.statusCode).toEqual(200);
+        done();
+      });
       it('should edit team successfully if details are correct', async (done) => {
         const res = await request(app)
           .patch(`${ApiPrefix}/teams/${teamId}`)

--- a/src/routes/teamRoute.js
+++ b/src/routes/teamRoute.js
@@ -6,13 +6,15 @@ import checkTeam from '../middlewares/checkTeam';
 import Cache from '../helpers/cache';
 import rateLimiter from '../middlewares/rateLimiter';
 
-const { addTeam, getAllTeams, getTeam, editTeam } = teamController;
+const { addTeam, getAllTeams, getTeam, editTeam, search } = teamController;
 const { verifyToken, verifyAdmin } = Authentication;
-const { getCachedTeams } = Cache;
+const { getCachedTeams, getCachedSearchResults } = Cache;
 
 const router = Router();
 
 router.post('/', verifyToken, verifyAdmin, validate.newTeam, checkTeam, addTeam);
+// Search route is the only one that requires no authentication
+router.get('/search', getCachedSearchResults, search);
 router.get('/', verifyToken, rateLimiter, getCachedTeams, getAllTeams);
 router.get('/:id', verifyToken, validate.validateId, getTeam);
 router.patch('/:id', verifyToken, validate.validateId, editTeam);


### PR DESCRIPTION
Creates a search endpoint that requires no authentication and allows users search for their teams and their fixtures
[Finishes #171037171]

### What does this PR do?

#### Description of Task to be completed?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)