### PR TITLE
#171037213 Admin can update scores for both home and away teams

### DIFF
--- a/src/__tests__/updateScores.test.js
+++ b/src/__tests__/updateScores.test.js
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import app from '../sampleApp';
+import mockAdmins from '../helpers/mockData/mockAdmins';
+import mockFixtures from '../helpers/mockData/mockFixtures';
+
+
+
+const {
+    finalFixture,
+ } = mockFixtures;
+
+ const { correctDetails } = mockAdmins;
+
+ let adminToken;
+ let fixtureId;
+ const ApiPrefix = '/api/v1';
+
+ beforeAll(async () => {
+    const adminResponse = await request(app)
+      .post(`${ApiPrefix}/admin/signup`)
+      .send({
+          firstName: 'admin',
+          lastName: 'Taylor',
+          email: 'admin.taylor@mail.com',
+          password: correctDetails.password,
+          confirmPassword: correctDetails.password,
+      })
+        adminToken = adminResponse.body.user.token;
+    const fixtureResponse = await request(app)
+      .post(`${ApiPrefix}/fixtures`)
+      .send(finalFixture)
+      .set('Authorization', `Bearer ${adminToken}`)
+      fixtureId = fixtureResponse.body.Fixture.id;
+});
+
+describe('admin increment and decrement scores', () => {
+    it('should increment home team score by one', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/hometeam/inc`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.homeTeam.score).toEqual(1);
+        done();
+      });
+      it('should decrement home team score by one', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/hometeam/dcr`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.homeTeam.score).toEqual(0);
+        done();
+      });
+      it('should not decrement home team score by one if current score is zero', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/hometeam/dcr`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.homeTeam.score).toEqual(0);
+        expect(res.body.Fixture.message).toEqual('Home Team\'s Score cannot be decreased below 0!')
+        done();
+      });
+      it('should increment away team score by one', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/awayteam/inc`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.awayTeam.score).toEqual(1);
+        done();
+      });
+      it('should decrement away team score by one', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/awayteam/dcr`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.awayTeam.score).toEqual(0);
+        done();
+      });
+      it('should not decrement away team score by one if current score is zero', async (done) => {
+        const res = await request(app)
+          .patch(`${ApiPrefix}/fixtures/${fixtureId}/awayteam/dcr`)
+          .set('Authorization', `Bearer ${adminToken}`)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.Fixture.homeTeam.score).toEqual(0);
+        expect(res.body.Fixture.message).toEqual('Away Team\'s Score cannot be decreased below 0!')
+        done();
+      });
+    });

--- a/src/controllers/fixtureController.js
+++ b/src/controllers/fixtureController.js
@@ -137,8 +137,147 @@ static async getPendingFixtures (req, res) {
           });
 } catch (err) {
     return serverErrorResponse(err, req, res);
-}
-}
+        }
+    }
+static async incrementHomeTeamScore(req, res) {
+    const fixtureId = req.params.id;
+    try {
+        const checkFixture = await Fixture.findOne({ _id: fixtureId});
+        if(!checkFixture) {
+            return errorResponse(res, 404, { message: 'Fixture not found' });            }
+            const updateScore = await Fixture.findOneAndUpdate(
+                { _id: fixtureId },
+                { $inc: { 'homeTeam.score': 1 },
+                          updatedAt: new Date()  },
+                { new: true },
+              );
+            return successResponse(res, 200, 'Fixture', {
+                message: 'Score Updated!',
+                id: updateScore.id,
+                homeTeam: updateScore.homeTeam,
+                awayTeam: updateScore.awayTeam,
+                referee: updateScore.referee,
+                happeningOn: updateScore.happeningOn,
+                addedAt: updateScore.addedAt,
+                updatedAt: updateScore.updatedAt
+              });
+    } catch (err) {
+        console.log(err)
+        return serverErrorResponse(err, req, res);
+            }
+    }
+     
+static async incrementAwayTeamScore(req, res) {
+        const fixtureId = req.params.id;
+        try {
+            const checkFixture = await Fixture.findOne({ _id: fixtureId});
+              if(!checkFixture) {
+                    return errorResponse(res, 404, { message: 'Fixture not found' });
+                }
+            const updateScore = await Fixture.findOneAndUpdate(
+                    { _id: fixtureId },
+                    { $inc: { 'awayTeam.score': 1 },
+                              updatedAt: new Date() },
+                    { new: true },
+                  );
+            return successResponse(res, 200, 'Fixture', {
+                    message: 'Score Updated!',
+                    id: updateScore.id,
+                    homeTeam: updateScore.homeTeam,
+                    awayTeam: updateScore.awayTeam,
+                    referee: updateScore.referee,
+                    happeningOn: updateScore.happeningOn,
+                    addedAt: updateScore.addedAt,
+                    updatedAt: updateScore.updatedAt
+                  });
+        } catch (err) {
+            console.log(err)
+            return serverErrorResponse(err, req, res);
+        }
+} 
+     
+static async decrementHomeTeamScore(req, res) {
+    const fixtureId = req.params.id;
+    try {
+        const checkFixture = await Fixture.findOne({ _id: fixtureId});
+            if(!checkFixture) {
+                return errorResponse(res, 404, { message: 'Fixture not found' });
+            }
+            const scoreIsZero = await Fixture.findOne({ _id: fixtureId, 'homeTeam.score': { $lt: 1 } })
+           if (scoreIsZero) {
+                return successResponse(res, 200, 'Fixture', {
+                    message: 'Home Team\'s Score cannot be decreased below 0!',
+                    id: scoreIsZero.id,
+                    homeTeam: scoreIsZero.homeTeam,
+                    awayTeam: scoreIsZero.awayTeam,
+                    referee: scoreIsZero.referee,
+                    happeningOn: scoreIsZero.happeningOn,
+                    addedAt: scoreIsZero.addedAt,
+                    updatedAt: scoreIsZero.updatedAt
+                 });
+            }
+        const updateScore = await Fixture.findOneAndUpdate(
+                { _id: fixtureId },
+                { $inc: { 'homeTeam.score': -1 },
+                  updatedAt: new Date()  },
+                { new: true },
+                );
+        return successResponse(res, 200, 'Fixture', {
+                message: 'Score Updated!',
+                id: updateScore.id,
+                homeTeam: updateScore.homeTeam,
+                awayTeam: updateScore.awayTeam,
+                referee: updateScore.referee,
+                happeningOn: updateScore.happeningOn,
+                addedAt: updateScore.addedAt,
+                updatedAt: updateScore.updatedAt
+            });
+        } catch (err) {
+            return serverErrorResponse(err, req, res);
+    }
+    }
+static async decrementAwayTeamScore(req, res) {
+    const fixtureId = req.params.id;
+        try {
+            const checkFixture = await Fixture.findOne({ _id: fixtureId});
+            if(!checkFixture) {
+                return errorResponse(res, 404, { message: 'Fixture not found' });
+            }
+            const scoreIsZero = await Fixture.findOne({ _id: fixtureId, 'awayTeam.score': { $lt: 1 } })
+            if (scoreIsZero) {
+                return successResponse(res, 200, 'Fixture', {
+                    message: 'Away Team\'s Score cannot be decreased below 0!',
+                    id: scoreIsZero.id,
+                    homeTeam: scoreIsZero.homeTeam,
+                    awayTeam: scoreIsZero.awayTeam,
+                    referee: scoreIsZero.referee,
+                    happeningOn: scoreIsZero.happeningOn,
+                    addedAt: scoreIsZero.addedAt,
+                    updatedAt: scoreIsZero.updatedAt
+                });
+            }
+            const updateScore = await Fixture.findOneAndUpdate(
+                    { _id: fixtureId },
+                    { $inc: { 'awayTeam.score': -1 },
+                          updatedAt: new Date()  },
+                     { new: true },
+                  );
+                return successResponse(res, 200, 'Fixture', {
+                    message: 'Score Updated!',
+                    id: updateScore.id,
+                    homeTeam: updateScore.homeTeam,
+                    awayTeam: updateScore.awayTeam,
+                    referee: updateScore.referee,
+                    happeningOn: updateScore.happeningOn,
+                    addedAt: updateScore.addedAt,
+                    updatedAt: updateScore.updatedAt
+                });
+        } catch (err) {
+            console.log(err)
+            return serverErrorResponse(err, req, res);
+            }
+    } 
+               
            
 }
  

--- a/src/helpers/mockData/mockFixtures.js
+++ b/src/helpers/mockData/mockFixtures.js
@@ -108,6 +108,15 @@ const mockFixtures = {
         referee: 'Segun Amhed',
         city: 'Abuja',
         country: 'Nigeria',
+    },
+    finalFixture: {
+        homeTeam: 'Owls FC',
+        awayTeam: 'Crows FC',
+        stadium: 'Owl City',
+        happeningOn: '2020-02-04T12:30',
+        referee: 'Robinson',
+        city: 'Abuja',
+        country: 'Nigeria', 
     }
 };
 

--- a/src/routes/fixtureRoute.js
+++ b/src/routes/fixtureRoute.js
@@ -5,13 +5,19 @@ import validate from '../middlewares/fixtureValidation';
 import Cache from '../helpers/cache';
 import rateLimiter from '../middlewares/rateLimiter';
 
-const { addFixture,
+const {
+        addFixture,
         getFixture,
         getFixtureForAdmin,
         editFixture,
         getCompletedFixtures,
         getPendingFixtures,
-    } = FixtureController;
+        incrementHomeTeamScore,
+        incrementAwayTeamScore,
+        decrementHomeTeamScore,
+        decrementAwayTeamScore,
+      } = FixtureController;
+
 const { verifyToken, verifyAdmin } = Authentication;
 const { getCachedCompletedFixtures, getCachedPendingFixtures } = Cache;
 const router = Router();
@@ -22,5 +28,9 @@ router.get('/pending', verifyToken, rateLimiter, getCachedPendingFixtures, getPe
 router.get('/:id', verifyToken, validate.validateId, getFixture);
 router.get('/:id/admin', verifyToken, verifyAdmin, validate.validateId, getFixtureForAdmin);
 router.patch('/:id', verifyToken, verifyAdmin, validate.validateId, validate.fixture, editFixture);
+router.patch('/:id/hometeam/inc', verifyToken, verifyAdmin, validate.validateId, incrementHomeTeamScore);
+router.patch('/:id/awayTeam/inc', verifyToken, verifyAdmin, validate.validateId, incrementAwayTeamScore);
+router.patch('/:id/hometeam/dcr', verifyToken, verifyAdmin, validate.validateId, decrementHomeTeamScore);
+router.patch('/:id/awayteam/dcr', verifyToken, verifyAdmin, validate.validateId, decrementAwayTeamScore);
 
 export default router;


### PR DESCRIPTION
create admin endpoints for:
incrementing score
and decrementing score for home and away teams
[Finishes #171037213]

### What does this PR do?

#### Description of Task to be completed?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)